### PR TITLE
Feature/autorelease - Publish automatically the Kubevirt releases on user-guide page 

### DIFF
--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -98,6 +98,7 @@ function git_configure() {
     [[ -z ${USERNAME} ]] && (get_git_field "username" && USERNAME=${RESULT})
     [[ -z ${TOKEN} ]] && (get_git_field "password" && TOKEN=${RESULT})
     ln -fs /etc/gitconfig/git-config ${HOME}/.gitconfig
+    ls -lah ${HOME}
 
     git remote set-url origin https://${USERNAME}:${TOKEN}@${REPO}
 }

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -2,6 +2,8 @@
 # Description: This script generates markdown files for each release of kubevirt in repository
 # Generated markdown files should be stored under _posts/ for website rendering
 
+set +x
+
 TARGET='build'
 BOT="$1"
 

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -110,6 +110,6 @@ for file in build/artifacts/*.markdown; do
 done
 
 git add _posts/
-git commit -m "Release autobot 🚗---->🤖"
 git_configure "${BOT}"
+git commit -m "Release autobot 🚗---->🤖"
 git push --set-upstream origin master

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -94,6 +94,7 @@ function git_configure() {
     USERNAME="${1:-kubevirt-bot}"
     TOKEN="$2"
     REPO="$(git config --get remote.origin.url | cut -f2 -d@ | cut -f3-$NC -d/)"
+    BRANCH="feature/autorelease"
 
     [[ -z ${USERNAME} ]] && (get_git_field "username" && USERNAME=${RESULT})
     get_git_field "password" && TOKEN=${RESULT}
@@ -111,4 +112,4 @@ done
 git add _posts/
 git_configure "${BOT}"
 git commit -m "Release autobot 🚗---->🤖"
-git push --set-upstream origin master
+git push --set-upstream origin ${BRANCH} 

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -32,6 +32,7 @@ function features_for() {
 
 function gen_changelog() {
   {
+  echo "Generating changelog from Git Tags..."
   for REL in $(releases);
   do
     FILENAME="changelog-$REL.markdown"
@@ -66,6 +67,7 @@ EOF
     mv $FILENAME $NEWFILENAME
     sed -i "s#^pub-date:.*#pub-date: $monthname#g" "$NEWFILENAME"
     sed -i "s#^pub-year:.*#pub-year: $year#g" "$NEWFILENAME"
+    echo "File ${NEWFILENAME} created"
   done
   }
 }

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -93,7 +93,7 @@ function git_configure() {
     # is not the correct one to work with credentials properly, even creating the secret
     USERNAME="${1:-kubevirt-bot}"
     TOKEN="$2"
-    REPO="$(git config --get remote.origin.url | cut -f2 -d@)"
+    REPO="$(git config --get remote.origin.url | cut -f2 -d@ | cut -f3-$NC -d/)"
 
     [[ -z ${USERNAME} ]] && (get_git_field "username" && USERNAME=${RESULT})
     get_git_field "password" && TOKEN=${RESULT}

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -97,7 +97,7 @@ function git_configure() {
 
     [[ -z ${USERNAME} ]] && (get_git_field "username" && USERNAME=${RESULT})
     [[ -z ${TOKEN} ]] && (get_git_field "password" && TOKEN=${RESULT})
-    [[ -L ${HOME}/.gitconfig ]] || ln -s /etc/gitconfig/git-config ${HOME}/.gitconfig
+    ln -fs /etc/gitconfig/git-config ${HOME}/.gitconfig
 
     git remote set-url origin https://${USERNAME}:${TOKEN}@${REPO}
 }

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -96,9 +96,8 @@ function git_configure() {
     REPO="$(git config --get remote.origin.url | cut -f2 -d@)"
 
     [[ -z ${USERNAME} ]] && (get_git_field "username" && USERNAME=${RESULT})
-    [[ -z ${TOKEN} ]] && (get_git_field "password" && TOKEN=${RESULT})
+    get_git_field "password" && TOKEN=${RESULT}
     ln -fs /etc/gitconfig/git-config ${HOME}/.gitconfig
-    ls -lah ${HOME}
 
     git remote set-url origin https://${USERNAME}:${TOKEN}@${REPO}
 }


### PR DESCRIPTION
- Autorelease finished with autopush to the current branch
- You will need some requirements on your Prow instance and config:

Related Config:
```
presets:
- labels:
    preset-gh-config: "true"
  volumes:
  - name: git-config
    secret:
        defaultMode: 420
        secretName: git-config
  volumeMounts:
  - name: git-config
    mountPath: /etc/gitconfig
    readOnly: true
#######
- labels:
    preset-gh-pusher: "true"
  volumes:
  - name: git-creds
    secret:
        defaultMode: 420
        secretName: git-creds
  volumeMounts:
  - name: git-creds
    mountPath: /etc/git-creds
    readOnly: true
#######
```

The related job:
```
periodics:
  - interval: 24h
    name: kubevirt-io-periodic-release-changelog
    decorate: true
    labels:
      preset-gh-config: "true"
      preset-gh-pusher: "true"
    spec:
      nodeSelector:
        region: primary
      containers:
        - image: docker.io/library/ruby
          env:
            - name: NOKOGIRI_USE_SYSTEM_LIBRARIES
              value: "true"
          command: ["/bin/sh", "-c"]
          args: ["git clone -b feature/autorelease --single-branch https://github.com/the-shadowmen/kubevirt.github.io.git && cd kubevirt.github.io && ./scripts/update_changelog.sh bot-name"]
```
*NOTE*: Some changes will needed in order to make this work on kubevirt's Prow instance (like the bot-name, the secret location and format)

We need 2 secrets, 1 with Git Config and another with git-credentials (token), the final files will be something like:

- git-config (in kubevirts Prow instance this may change)
```
[user]
	email = bot-email@gmail.com
	name = bot-name
[credential]
	helper = store --file /etc/git-creds/.git-credentials
```

- git-credentials
```
[credential "https://github.com"]
	username=bot-name
	password=xxxxxxxxxxxxXXXXXXXXXxxxxxxxxxxxxx
```